### PR TITLE
fix: Refactor static file server handler and logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,22 @@
+package spaserve
+
+import (
+	"context"
+	"log/slog"
+)
+
+type servespaLogger struct {
+	logger *slog.Logger
+}
+
+// newLogger creates a new logger function with the given context and logger.
+func newLogger(logger *slog.Logger) *servespaLogger {
+	return &servespaLogger{logger: logger}
+}
+
+func (l servespaLogger) logContext(ctx context.Context, level slog.Level, msg string, attrs ...slog.Attr) {
+	if l.logger == nil {
+		return
+	}
+	l.logger.LogAttrs(ctx, level, msg, attrs...)
+}


### PR DESCRIPTION
Refactor the code in staticFileServerHandler.go and logger.go to improve code organization and readability. The changes include:
- Move the logger related functions to a separate file, logger.go, for better separation of concerns.
- Rename the StaticFilesHandler function to NewStaticFilesHandler to follow the Go convention for constructor functions.
- Extract the ServeHTTP method from the StaticFilesHandler function and move it to the StaticFilesHandler struct to improve encapsulation.
- Clean up the code by removing unused imports and variables.

This commit improves the maintainability and readability of the codebase.